### PR TITLE
V0.1.1 configuration updates for deploying storybook-react-ui

### DIFF
--- a/apps/storybook-react-ui/package.json
+++ b/apps/storybook-react-ui/package.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "scripts": {
     "dev": "storybook dev -p 6006",
-    "build": "storybook build",
+    "build": "storybook build --output-dir dist",
     "lint": "eslint . --ext .ts,.tsx",
     "preview": "storybook preview",
-    "clean": "rm -rf storybook-static dist .turbo"
+    "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
     "@gmzh/react-ui": "latest",

--- a/apps/storybook-react-ui/vercel.json
+++ b/apps/storybook-react-ui/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "pnpm build",
+  "outputDirectory": "dist",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "framework": null
+}

--- a/apps/storybook-react-ui/vercel.json
+++ b/apps/storybook-react-ui/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "pnpm build",
   "outputDirectory": "dist",
-  "installCommand": "pnpm install --frozen-lockfile",
+  "installCommand": "pnpm install --no-frozen-lockfile",
   "framework": null
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
   apps/storybook-react-ui:
     dependencies:
       '@gmzh/react-ui':
-        specifier: latest
-        version: 0.1.3(react@18.3.1)
+        specifier: ^0.1.4
+        version: 0.1.4(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -609,8 +609,8 @@ packages:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@gmzh/react-ui@0.1.3':
-    resolution: {integrity: sha512-Kx1zUTsk69zNAyk+miWbPJby7kGnjCbZOAv71NplJgTYc9hrJtEymBQ8mut/AbxLZiUgKmhfUNxluXlZHe6sNg==}
+  '@gmzh/react-ui@0.1.4':
+    resolution: {integrity: sha512-4WaArp2Jw0EGYyUoM3ipxXE+2AEwwon7m+eQ8duMH7ASywWODXlhfRBuVL3Qq5pPUN6r8C/whzdReRLnHhmh/g==}
     peerDependencies:
       react: ^18.2.0
 
@@ -3239,7 +3239,7 @@ snapshots:
 
   '@eslint/js@8.56.0': {}
 
-  '@gmzh/react-ui@0.1.3(react@18.3.1)':
+  '@gmzh/react-ui@0.1.4(react@18.3.1)':
     dependencies:
       class-variance-authority: 0.7.1
       clsx: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
   apps/storybook-react-ui:
     dependencies:
       '@gmzh/react-ui':
-        specifier: ^0.1.4
+        specifier: latest
         version: 0.1.4(react@18.3.1)
       react:
         specifier: ^18.2.0


### PR DESCRIPTION
This pull request updates the Storybook React UI app to improve its build process and deployment configuration, and upgrades the `@gmzh/react-ui` dependency to the latest version. The changes streamline how the app is built and cleaned, and add configuration for Vercel deployment.

**Build and Deployment Improvements:**

* Updated the `build` script in `package.json` to output the build files to the `dist` directory, and simplified the `clean` script to only remove `dist` and `.turbo` directories. (`apps/storybook-react-ui/package.json`)
* Added a new `vercel.json` file to configure Vercel deployment, specifying the build and install commands, output directory, and disabling framework detection. (`apps/storybook-react-ui/vercel.json`)

**Dependency Updates:**

* Upgraded `@gmzh/react-ui` from version `0.1.3` to `0.1.4` in the lockfile, updating all relevant references and dependencies. (`pnpm-lock.yaml`) [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL85-R85) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL612-R613) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3242-R3242)