### PR TITLE
storybook-v2.1.0 updated storybook env

### DIFF
--- a/apps/storybook-react-ui/.storybook/environment.mts
+++ b/apps/storybook-react-ui/.storybook/environment.mts
@@ -1,5 +1,4 @@
 import path from 'path';
-import fs from 'fs';
 import { fileURLToPath } from 'url';
 
 // Get current directory in ES modules

--- a/apps/storybook-react-ui/.storybook/environment.mts
+++ b/apps/storybook-react-ui/.storybook/environment.mts
@@ -1,0 +1,47 @@
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+// Get current directory in ES modules
+const currentFilename = fileURLToPath(import.meta.url);
+const currentDirname = path.dirname(currentFilename);
+
+// Environment configuration for Storybook
+export const isProduction = process.env.NODE_ENV === 'production';
+export const isDevelopment = !isProduction;
+
+// Paths configuration
+export const paths = {
+  // Local workspace package path
+  localPackage: path.resolve(currentDirname, '../../../packages/@react-ui/src'),
+  localComponents: path.resolve(
+    currentDirname,
+    '../../../packages/@react-ui/src/lib/components',
+  ),
+  localStyles: path.resolve(
+    currentDirname,
+    '../../../packages/@react-ui/src/lib/system/globals.css',
+  ),
+
+  // Published package paths
+  publishedPackage: path.resolve(
+    currentDirname,
+    '../node_modules/@gmzh/react-ui',
+  ),
+  publishedComponents: path.resolve(
+    currentDirname,
+    '../node_modules/@gmzh/react-ui/dist/lib/components',
+  ),
+};
+
+export const getStoriesPath = () => {
+  return isProduction
+    ? `${paths.publishedComponents}/**/*.stories.@(js|jsx|ts|tsx|mjs|cjs)`
+    : `${paths.localComponents}/**/*.stories.@(js|jsx|ts|tsx|mjs|cjs)`;
+};
+
+export const getPackageAlias = () => {
+  return isProduction
+    ? { '@gmzh/react-ui': paths.publishedPackage }
+    : { '@gmzh/react-ui': paths.localPackage };
+};

--- a/apps/storybook-react-ui/.storybook/main.mts
+++ b/apps/storybook-react-ui/.storybook/main.mts
@@ -1,6 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 import {
-  isProduction,
   isDevelopment,
   getStoriesPath,
   getPackageAlias,

--- a/apps/storybook-react-ui/.storybook/main.mts
+++ b/apps/storybook-react-ui/.storybook/main.mts
@@ -1,17 +1,15 @@
 import type { StorybookConfig } from '@storybook/react-vite';
-import path from 'path';
+import {
+  isProduction,
+  isDevelopment,
+  getStoriesPath,
+  getPackageAlias,
+} from './environment.mts';
 
 // !https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated
 
 const config: StorybookConfig = {
-  stories: [
-    // consume stories from the installed @gmzh/react-ui package
-    `${path.resolve(
-      __dirname,
-      '../node_modules/@gmzh/react-ui/dist/lib/components',
-    )}/**/*.stories.@(js|jsx|ts|tsx|mjs|cjs)`,
-    // No local stories; only render package stories
-  ],
+  stories: [getStoriesPath()],
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-links',
@@ -26,7 +24,25 @@ const config: StorybookConfig = {
   },
   viteFinal: async (config) => {
     const { mergeConfig } = await import('vite');
-    return mergeConfig(config, {});
+
+    return mergeConfig(config, {
+      resolve: {
+        alias: getPackageAlias(),
+      },
+      // Allow file system access to the packages directory in development
+      server: isDevelopment
+        ? {
+            fs: {
+              allow: ['..', '../..', '../../packages'],
+            },
+          }
+        : undefined,
+      // Include workspace packages in dependency optimization for development
+      optimizeDeps: {
+        include: ['react', 'react-dom'],
+        exclude: isDevelopment ? ['@gmzh/react-ui'] : [],
+      },
+    });
   },
 };
 

--- a/apps/storybook-react-ui/package.json
+++ b/apps/storybook-react-ui/package.json
@@ -5,14 +5,16 @@
   "author": "GMZhang",
   "license": "MIT",
   "scripts": {
-    "dev": "storybook dev -p 6006",
-    "build": "storybook build --output-dir dist",
+    "dev": "NODE_ENV=development storybook dev -p 6006",
+    "dev:prod": "NODE_ENV=production storybook dev -p 6006",
+    "build": "NODE_ENV=production storybook build --output-dir dist",
+    "build:dev": "NODE_ENV=development storybook build --output-dir dist",
     "lint": "eslint . --ext .ts,.tsx",
     "preview": "storybook preview",
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
-    "@gmzh/react-ui": "latest",
+    "@gmzh/react-ui": "0.2.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/apps/storybook-react-ui/package.json
+++ b/apps/storybook-react-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-react-ui",
-  "version": "1.1.0",
+  "version": "2.1.0",
   "private": true,
   "author": "GMZhang",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
   apps/storybook-react-ui:
     dependencies:
       '@gmzh/react-ui':
-        specifier: latest
-        version: 0.1.4(react@18.3.1)
+        specifier: 0.2.5
+        version: 0.2.5(react@18.3.1)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -616,8 +616,8 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@gmzh/react-ui@0.1.4':
-    resolution: {integrity: sha512-4WaArp2Jw0EGYyUoM3ipxXE+2AEwwon7m+eQ8duMH7ASywWODXlhfRBuVL3Qq5pPUN6r8C/whzdReRLnHhmh/g==}
+  '@gmzh/react-ui@0.2.5':
+    resolution: {integrity: sha512-VscceZrKEkPS4nd3tPoB5HzdlhjQqYRL+09p/rpelc6L3GU13Wo13G7eGFrJ0OjUVDofozmVEws5IPBpXp/PFg==}
     peerDependencies:
       react: ^18.2.0
 
@@ -3256,7 +3256,7 @@ snapshots:
 
   '@eslint/js@8.57.1': {}
 
-  '@gmzh/react-ui@0.1.4(react@18.3.1)':
+  '@gmzh/react-ui@0.2.5(react@18.3.1)':
     dependencies:
       class-variance-authority: 0.7.1
       clsx: 2.1.1


### PR DESCRIPTION
This pull request refactors the Storybook configuration for the `storybook-react-ui` app to support both local development and production environments more flexibly. The main changes include introducing environment-based configuration, centralizing path and alias logic, and updating scripts to handle different environments.

**Environment-based configuration and path management:**

* Added `environment.mts` to centralize environment detection (`isProduction`, `isDevelopment`), workspace and published package paths, and helper functions for resolving stories and package aliases.
* Updated `main.mts` to use the new environment helpers (`getStoriesPath`, `getPackageAlias`) for determining which stories to load and how to alias the package, removing hardcoded paths.

**Development and build process improvements:**

* Enhanced the Vite configuration in Storybook to set up file system access, dependency optimization, and aliasing based on the environment, improving local development with workspace packages.
* Modified `package.json` scripts to explicitly set `NODE_ENV` for development and production builds, adding new commands for both environments.
* Updated the `@gmzh/react-ui` dependency version to `0.2.5` for better consistency with published releases.