### PR TITLE
v0.2.9 refactor on components

### DIFF
--- a/apps/storybook-react-ui/README.md
+++ b/apps/storybook-react-ui/README.md
@@ -1,60 +1,164 @@
 # Storybook React UI
 
-A Storybook application for showcasing and developing React UI components from the `@react-ui` package.
+**🌐 [View Live Documentation →](https://storybook-react-ui.vercel.app)**
 
-## Overview
+Interactive documentation and development environment for the `@gmzh/react-ui` component library. This Storybook instance provides a comprehensive playground for exploring, testing, and developing React UI components.
 
-This Storybook instance serves as a development environment and documentation for the React UI component library. It provides an interactive playground for developing, testing, and documenting components.
+## 🎯 Overview
 
-## Getting Started
+This Storybook application serves multiple purposes:
+
+- **Component Showcase** - Visual catalog of all available UI components
+- **Development Environment** - Real-time component development and testing
+- **Documentation Hub** - Interactive examples with props and usage patterns
+
+## 🚀 Quick Start
 
 ### Prerequisites
 
-- Node.js (v16 or higher)
-- pnpm
+- Node.js (v20.11.1 or higher)
+- pnpm (v9.11.0 or higher)
 
-### Installation
+### Local Development
 
 ```bash
-# Install dependencies
+# From the monorepo root
 pnpm install
+
+# Start Storybook development server
+pnpm storybook
+# or
+pnpm --filter storybook-react-ui dev
+
+# Visit http://localhost:6006
 ```
 
-### Development
+### Production Build
 
 ```bash
-# Start Storybook in development mode
-pnpm dev
+# Build static Storybook site
+pnpm storybook:build
+# or
+pnpm --filter storybook-react-ui build
 ```
 
-### Build
+## 📁 Project Structure
 
-```bash
-# Build Storybook for production
-pnpm build
+```
+apps/storybook-react-ui/
+├── .storybook/              # Storybook configuration
+│   ├── main.ts             # Main config & addons
+│   ├── preview.ts          # Global parameters & decorators
+│   └── manager.ts          # Manager UI customization
+├── src/                    # Demo components & utilities
+│   ├── Component.tsx       # Component showcase examples
+│   ├── App.tsx            # Root demo application
+│   └── stories/           # Custom story files
+└── public/                # Static assets
 ```
 
-## Project Structure
+## ✨ Features
 
-- `src/` - Source files for the Storybook application
-- `.storybook/` - Storybook configuration files
-- `src/Component.tsx` - Main component showcase
-- `src/App.tsx` - Root application component
+- **🎨 Theme Support** - Seamless light/dark mode switching with system detection
+- **📱 Responsive Design** - Mobile-first component testing across breakpoints
+- **♿ Accessibility** - Built-in a11y addon for compliance testing
+- **🎮 Interactive Controls** - Dynamic prop manipulation in real-time
+- **📖 Auto-Documentation** - Generated docs from TypeScript types
+- **🔍 Component Search** - Quick navigation and filtering
+- **📊 Design Tokens** - Visual design system documentation
 
-## Features
+## 🛠️ Development Workflow
 
-- Component development environment
-- Interactive component documentation
-- Theme support with dark/light mode
-- Tailwind CSS integration
+### Adding New Components
 
-## Contributing
+1. **Create Component** in `packages/@react-ui/src/lib/components/`:
 
-When adding new components:
+   ```bash
+   mkdir packages/@react-ui/src/lib/components/NewComponent
+   ```
 
-1. Create component files in `@react-ui/src/lib/components`
-2. Add corresponding stories in the component directory
-3. Update the component showcase in `src/Component.tsx` if needed
+2. **Add Stories** alongside your component:
+
+   ```typescript
+   // NewComponent.stories.tsx
+   import type { Meta, StoryObj } from '@storybook/react';
+   import { NewComponent } from './NewComponent';
+
+   const meta: Meta<typeof NewComponent> = {
+     title: 'Components/NewComponent',
+     component: NewComponent,
+     parameters: {
+       layout: 'centered',
+     },
+   };
+   export default meta;
+   ```
+
+3. **Export Component** in `packages/@react-ui/src/index.ts`
+
+4. **Test in Storybook** - Component automatically appears in the sidebar
+
+### Story Best Practices
+
+```typescript
+// Example story with multiple variants
+export const Default: StoryObj<typeof NewComponent> = {
+  args: {
+    variant: 'primary',
+    size: 'md',
+  },
+};
+
+export const AllVariants: StoryObj<typeof NewComponent> = {
+  render: () => (
+    <div className='space-y-4'>
+      <NewComponent variant='primary'>Primary</NewComponent>
+      <NewComponent variant='secondary'>Secondary</NewComponent>
+    </div>
+  ),
+};
+```
+
+## 🎨 Available Components
+
+### Form Controls
+
+- **Button** - Primary actions with multiple variants
+- **TextField** - Text input with validation states
+- **Select** - Dropdown selection with search
+- **Checkbox** - Binary selection with indeterminate state
+- **Switch** - Toggle controls with labels
+- **TextArea** - Multi-line text input
+
+### Layout & Structure
+
+- **Box** - Flexible container with spacing props
+- **Flex** - Flexbox layout utilities
+- **Typography** - Text styling and hierarchy
+
+### Navigation
+
+- **Tabs** - Tabbed navigation with keyboard support
+
+### Feedback & Status
+
+- **Alert** - Contextual messages and notifications
+- **Badge** - Status indicators and counts
+- **Spinner** - Loading states and progress
+- **Tooltip** - Contextual help and information
+
+### System
+
+- **ThemeProvider** - Global theme management
+
+## 🌐 Deployment
+
+The Storybook is automatically deployed to Vercel on every push to the main branch:
+
+- **Production**: https://storybook-react-ui.vercel.app
+- **Preview Builds**: Generated for pull requests
+
+## 🤝 Contributing
 
 ## 📄 License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ui",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "author": "GMZhang",
   "license": "MIT",

--- a/packages/@react-ui/.eslintrc.cjs
+++ b/packages/@react-ui/.eslintrc.cjs
@@ -37,6 +37,8 @@ module.exports = {
     'react/default-props-match-prop-types': 'off',
     // Prefer default parameters over defaultProps for function components
     '@typescript-eslint/prefer-nullish-coalescing': 'warn',
+    // Allow prop spreading in component libraries for better DX
+    'react/jsx-props-no-spreading': 'off',
   },
   parserOptions: {
     project: [

--- a/packages/@react-ui/README.md
+++ b/packages/@react-ui/README.md
@@ -8,6 +8,7 @@ A comprehensive React UI component library built with TypeScript and Tailwind CS
 
 - **Components** - Complete UI toolkit from buttons to complex data tables
 - **TypeScript First** - Full type safety with excellent IntelliSense support
+- **React 19 Ready** - Full compatibility with React 18+ and React 19
 - **Dark Mode Built-in** - System-aware theme switching with custom CSS variables
 - **Zero Config** - Works out of the box, no Tailwind CSS setup required
 - **Accessibility** - ARIA compliant and keyboard navigable components

--- a/packages/@react-ui/package.json
+++ b/packages/@react-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gmzh/react-ui",
   "license": "MIT",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "A modern React UI component library with TypeScript",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/packages/@react-ui/src/lib/components/Box/Box.tsx
+++ b/packages/@react-ui/src/lib/components/Box/Box.tsx
@@ -135,51 +135,48 @@ export interface BoxProps
   extends Omit<React.HTMLAttributes<HTMLElement>, 'as'>,
     BoxBaseProps {
   as?: keyof JSX.IntrinsicElements;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
-  (
-    {
-      className,
-      display,
-      padding,
-      margin,
-      width,
-      height,
-      background,
-      border,
-      rounded,
-      shadow,
-      position,
-      as = 'div',
-      ...props
-    },
+export const Box = ({
+  className,
+  display,
+  padding,
+  margin,
+  width,
+  height,
+  background,
+  border,
+  rounded,
+  shadow,
+  position,
+  as = 'div',
+  ref,
+  ...props
+}: BoxProps) => {
+  const Component = (as || 'div') as keyof JSX.IntrinsicElements;
+  const elementProps = {
     ref,
-  ) => {
-    const Component = as ?? 'div';
-    const elementProps = {
-      ref,
-      className: cn(
-        boxVariants({
-          display,
-          padding,
-          margin,
-          width,
-          height,
-          background,
-          border,
-          rounded,
-          shadow,
-          position,
-        }),
-        className,
-      ),
-      ...props,
-    };
+    className: cn(
+      boxVariants({
+        display,
+        padding,
+        margin,
+        width,
+        height,
+        background,
+        border,
+        rounded,
+        shadow,
+        position,
+      }),
+      className,
+    ),
+    ...props,
+  };
 
-    return React.createElement(Component, elementProps);
-  },
-);
+  return React.createElement(Component, elementProps);
+};
 
 Box.displayName = 'Box';
 

--- a/packages/@react-ui/src/lib/components/Button/Button.tsx
+++ b/packages/@react-ui/src/lib/components/Button/Button.tsx
@@ -1,8 +1,9 @@
 // packages/ui/src/lib/components/Button/Button.tsx
 import { type VariantProps } from 'class-variance-authority';
-import { forwardRef } from 'react';
+import type React from 'react';
 
 import { cn } from '../../tools/classNames';
+import { extractAriaProps } from '../../tools/ariaHelpers';
 import { buttonVariants } from './button.config';
 
 /**
@@ -29,137 +30,87 @@ export interface ButtonProps
   endIcon?: React.ReactNode;
   loading?: boolean;
   loadingText?: string;
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  (
-    {
-      className,
-      variant,
-      size: buttonSize,
-      color,
-      fullWidth,
-      asChild: _asChild = false,
-      startIcon = null,
-      endIcon = null,
-      loading = false,
-      loadingText = 'Loading...',
-      children,
-      disabled,
-      ...props
-    },
-    ref,
-  ) => {
-    const getGapClass = (size: ButtonProps['size']) => {
-      switch (size) {
-        case 'tiny':
-          return 'gap-1';
-        case 'small':
-          return 'gap-1.5';
-        case 'medium':
-          return 'gap-2';
-        case 'large':
-          return 'gap-2.5';
-        default:
-          return 'gap-2';
-      }
-    };
+export const Button = ({
+  className,
+  variant,
+  size: buttonSize,
+  color,
+  fullWidth,
+  asChild: _asChild = false,
+  startIcon = null,
+  endIcon = null,
+  loading = false,
+  loadingText = 'Loading...',
+  children,
+  disabled,
+  ref,
+  ...props
+}: ButtonProps) => {
+  const { ariaProps, otherProps } = extractAriaProps(props);
+  const getGapClass = (size: ButtonProps['size']) => {
+    switch (size) {
+      case 'tiny':
+        return 'gap-1';
+      case 'small':
+        return 'gap-1.5';
+      case 'medium':
+        return 'gap-2';
+      case 'large':
+        return 'gap-2.5';
+      default:
+        return 'gap-2';
+    }
+  };
 
-    const {
-      id,
-      name,
-      value,
-      onClick,
-      onMouseEnter,
-      onMouseLeave,
-      onMouseDown,
-      onMouseUp,
-      onFocus,
-      onBlur,
-      onKeyDown,
-      onKeyUp,
-      title,
-      role,
-      tabIndex,
-      form,
-      formAction,
-      formMethod,
-      formNoValidate,
-      formTarget,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      'aria-describedby': ariaDescribedBy,
-    } = props;
-
-    return (
-      <button
-        ref={ref}
-        type='button'
-        className={cn(
-          buttonVariants({ variant, size: buttonSize, color, fullWidth }),
-          getGapClass(buttonSize),
-          className,
-        )}
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        disabled={disabled || loading}
-        id={id}
-        name={name}
-        value={value}
-        onClick={onClick}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
-        onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        onKeyDown={onKeyDown}
-        onKeyUp={onKeyUp}
-        title={title}
-        role={role}
-        tabIndex={tabIndex}
-        form={form}
-        formAction={formAction}
-        formMethod={formMethod}
-        formNoValidate={formNoValidate}
-        formTarget={formTarget}
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
-        aria-describedby={ariaDescribedBy}
-      >
-        {loading ? (
-          <>
-            <svg
-              className='animate-spin -ml-1 mr-2 h-4 w-4'
-              xmlns='http://www.w3.org/2000/svg'
-              fill='none'
-              viewBox='0 0 24 24'
-            >
-              <circle
-                className='opacity-25'
-                cx='12'
-                cy='12'
-                r='10'
-                stroke='currentColor'
-                strokeWidth='4'
-              />
-              <path
-                className='opacity-75'
-                fill='currentColor'
-                d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
-              />
-            </svg>
-            {loadingText ?? 'Loading...'}
-          </>
-        ) : (
-          <>
-            {startIcon}
-            {children}
-            {endIcon}
-          </>
-        )}
-      </button>
-    );
-  },
-);
+  return (
+    <button
+      ref={ref}
+      type='button'
+      className={cn(
+        buttonVariants({ variant, size: buttonSize, color, fullWidth }),
+        getGapClass(buttonSize),
+        className,
+      )}
+      disabled={disabled ?? loading}
+      {...ariaProps}
+      {...otherProps}
+    >
+      {loading ? (
+        <>
+          <svg
+            className='animate-spin -ml-1 mr-2 h-4 w-4'
+            xmlns='http://www.w3.org/2000/svg'
+            fill='none'
+            viewBox='0 0 24 24'
+          >
+            <circle
+              className='opacity-25'
+              cx='12'
+              cy='12'
+              r='10'
+              stroke='currentColor'
+              strokeWidth='4'
+            />
+            <path
+              className='opacity-75'
+              fill='currentColor'
+              d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'
+            />
+          </svg>
+          {loadingText ?? 'Loading...'}
+        </>
+      ) : (
+        <>
+          {startIcon}
+          {children}
+          {endIcon}
+        </>
+      )}
+    </button>
+  );
+};
 
 Button.displayName = 'Button';

--- a/packages/@react-ui/src/lib/components/Checkbox/Checkbox.tsx
+++ b/packages/@react-ui/src/lib/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,8 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import React, { forwardRef, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { cn } from '../../tools/classNames';
+import { normalizeAriaChecked } from '../../tools/ariaHelpers';
+import { mergeRefs } from '../../tools/refHelpers';
 
 /**
  * Checkbox Component
@@ -131,6 +133,7 @@ export interface CheckboxProps
     CheckboxBaseProps {
   icon?: React.ReactNode;
   indeterminate?: boolean;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 // Default check icon
@@ -149,10 +152,6 @@ const DefaultCheckIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
-DefaultCheckIcon.defaultProps = {
-  className: '',
-};
-
 // Indeterminate icon
 const IndeterminateIcon = ({ className }: { className?: string }) => (
   <svg
@@ -169,148 +168,121 @@ const IndeterminateIcon = ({ className }: { className?: string }) => (
   </svg>
 );
 
-IndeterminateIcon.defaultProps = {
-  className: '',
-};
+export const Checkbox = ({
+  className,
+  size,
+  color,
+  checked: checkedProp,
+  disabled,
+  icon,
+  indeterminate = false,
+  onChange,
+  ref,
+  ...props
+}: CheckboxProps) => {
+  const [internalChecked, setInternalChecked] = useState<boolean>(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  (
-    {
-      className,
-      size,
-      color,
-      checked: checkedProp,
-      disabled,
-      icon,
-      indeterminate = false,
-      onChange,
-      ...props
-    },
-    ref,
-  ) => {
-    const [internalChecked, setInternalChecked] = useState<boolean>(false);
-    const inputRef = useRef<HTMLInputElement>(null);
+  // Use controlled or uncontrolled state - pure derived state handles prop changes automatically
+  const checked = checkedProp !== undefined ? checkedProp : internalChecked;
 
-    // Use controlled or uncontrolled state - pure derived state handles prop changes automatically
-    const checked = checkedProp !== undefined ? checkedProp : internalChecked;
+  const handleCheckboxClick = (event: React.SyntheticEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
 
-    const handleCheckboxClick = (
-      event: React.SyntheticEvent<HTMLDivElement>,
-    ) => {
-      event.preventDefault();
-      event.stopPropagation();
+    if (!disabled && inputRef.current) {
+      // Trigger the actual input click which will handle state updates and onChange callback
+      inputRef.current.click();
+    }
+  };
 
-      if (!disabled && inputRef.current) {
-        // Trigger the actual input click which will handle state updates and onChange callback
-        inputRef.current.click();
-      }
-    };
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newChecked = event.target.checked;
 
-    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newChecked = event.target.checked;
+    // Update internal state only in uncontrolled mode
+    if (checkedProp === undefined) {
+      setInternalChecked(newChecked);
+    }
 
-      // Update internal state only in uncontrolled mode
-      if (checkedProp === undefined) {
-        setInternalChecked(newChecked);
-      }
+    // Call onChange callback once with the real event
+    onChange?.(event);
+  };
 
-      // Call onChange callback once with the real event
-      onChange?.(event);
-    };
+  // Helper function to determine which icon to show - clearer than nested ternary
+  const getIconToShow = () => {
+    if (indeterminate) {
+      return <IndeterminateIcon className='text-white' />;
+    }
+    if (icon) {
+      return React.isValidElement(icon)
+        ? React.cloneElement(icon, { className: 'text-white' })
+        : icon;
+    }
+    return <DefaultCheckIcon className='text-white' />;
+  };
 
-    // Helper function to determine which icon to show - clearer than nested ternary
-    const getIconToShow = () => {
-      if (indeterminate) {
-        return <IndeterminateIcon className='text-white' />;
-      }
-      if (icon) {
-        return React.cloneElement(icon as React.ReactElement, {
-          className: 'text-white',
-        });
-      }
-      return <DefaultCheckIcon className='text-white' />;
-    };
+  // Helper function to get aria-checked value - clearer than nested ternary
+  const getAriaChecked = () =>
+    normalizeAriaChecked(indeterminate ? 'mixed' : (checked ?? false));
 
-    // Helper function to get aria-checked value - clearer than nested ternary
-    const getAriaChecked = () => {
-      if (indeterminate) return 'mixed';
-      return checked ? 'true' : 'false';
-    };
-
-    return (
-      <div className='inline-flex items-center'>
-        <div
+  return (
+    <div className='inline-flex items-center'>
+      <div
+        className={cn(
+          checkboxVariants({
+            size,
+            color,
+            checked: checked ?? indeterminate,
+            disabled,
+          }),
+          className,
+        )}
+        onClick={handleCheckboxClick}
+        role='checkbox'
+        aria-checked={getAriaChecked()}
+        tabIndex={disabled ? -1 : 0}
+        onKeyDown={(e) => {
+          if (e.key === ' ') {
+            e.preventDefault();
+            handleCheckboxClick(e);
+          }
+        }}
+      >
+        <input
+          ref={mergeRefs([inputRef, ref])}
+          type='checkbox'
+          className='sr-only'
+          checked={!!checked}
+          disabled={!!disabled}
+          onChange={handleInputChange}
+          aria-hidden='true'
+          tabIndex={-1}
+          id={props.id}
+          name={props.name}
+          value={props.value}
+          required={props.required}
+          form={props.form}
+          onFocus={props.onFocus}
+          onBlur={props.onBlur}
+          onKeyDown={props.onKeyDown}
+          onKeyUp={props.onKeyUp}
+          aria-label={props['aria-label']}
+          aria-labelledby={props['aria-labelledby']}
+          aria-describedby={props['aria-describedby']}
+        />
+        <span
           className={cn(
-            checkboxVariants({
+            checkboxIconVariants({
               size,
-              color,
-              checked: checked ?? indeterminate,
-              disabled,
+              visible: checked ?? indeterminate,
             }),
-            className,
           )}
-          onClick={handleCheckboxClick}
-          role='checkbox'
-          aria-checked={getAriaChecked()}
-          tabIndex={disabled ? -1 : 0}
-          onKeyDown={(e) => {
-            if (e.key === ' ') {
-              e.preventDefault();
-              handleCheckboxClick(e);
-            }
-          }}
         >
-          <input
-            ref={(node) => {
-              const inputElement =
-                inputRef as React.MutableRefObject<HTMLInputElement | null>;
-              inputElement.current = node;
-              if (typeof ref === 'function') {
-                ref(node);
-              } else if (ref) {
-                const refObj =
-                  ref as React.MutableRefObject<HTMLInputElement | null>;
-                refObj.current = node;
-              }
-            }}
-            type='checkbox'
-            className='sr-only'
-            checked={!!checked}
-            disabled={!!disabled}
-            onChange={handleInputChange}
-            aria-hidden='true'
-            tabIndex={-1}
-            id={props.id}
-            name={props.name}
-            value={props.value}
-            required={props.required}
-            form={props.form}
-            onFocus={props.onFocus}
-            onBlur={props.onBlur}
-            onKeyDown={props.onKeyDown}
-            onKeyUp={props.onKeyUp}
-            aria-label={props['aria-label']}
-            aria-labelledby={props['aria-labelledby']}
-            aria-describedby={props['aria-describedby']}
-          />
-          <span
-            className={cn(
-              checkboxIconVariants({
-                size,
-                visible: checked ?? indeterminate,
-              }),
-            )}
-          >
-            {getIconToShow()}
-          </span>
-        </div>
+          {getIconToShow()}
+        </span>
       </div>
-    );
-  },
-);
+    </div>
+  );
+};
 
 Checkbox.displayName = 'Checkbox';
-Checkbox.defaultProps = {
-  icon: undefined,
-  indeterminate: false,
-};

--- a/packages/@react-ui/src/lib/components/Flex/Flex.tsx
+++ b/packages/@react-ui/src/lib/components/Flex/Flex.tsx
@@ -91,48 +91,45 @@ export interface FlexProps
   extends Omit<React.HTMLAttributes<HTMLElement>, 'as'>,
     FlexBaseProps {
   as?: keyof JSX.IntrinsicElements;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-export const Flex = React.forwardRef<HTMLDivElement, FlexProps>(
-  (
-    {
+export const Flex = ({
+  className,
+  direction,
+  align,
+  justify,
+  wrap,
+  gap,
+  width,
+  height,
+  grow,
+  shrink,
+  as = 'div',
+  ref,
+  ...props
+}: FlexProps) => {
+  const Component = (as || 'div') as keyof JSX.IntrinsicElements;
+  const elementProps = {
+    ref: ref as React.Ref<HTMLDivElement>,
+    className: cn(
+      flexVariants({
+        direction,
+        align,
+        justify,
+        wrap,
+        gap,
+        width,
+        height,
+        grow,
+        shrink,
+      }),
       className,
-      direction,
-      align,
-      justify,
-      wrap,
-      gap,
-      width,
-      height,
-      grow,
-      shrink,
-      as = 'div',
-      ...props
-    },
-    ref,
-  ) => {
-    const Component = as ?? 'div';
-    const elementProps = {
-      ref: ref as React.Ref<HTMLDivElement>,
-      className: cn(
-        flexVariants({
-          direction,
-          align,
-          justify,
-          wrap,
-          gap,
-          width,
-          height,
-          grow,
-          shrink,
-        }),
-        className,
-      ),
-      ...props,
-    };
+    ),
+    ...props,
+  };
 
-    return React.createElement(Component, elementProps);
-  },
-);
+  return React.createElement(Component, elementProps);
+};
 
 Flex.displayName = 'Flex';

--- a/packages/@react-ui/src/lib/components/Select/Select.tsx
+++ b/packages/@react-ui/src/lib/components/Select/Select.tsx
@@ -1,7 +1,6 @@
 import { type VariantProps } from 'class-variance-authority';
 import type React from 'react';
 import {
-  forwardRef,
   useId,
   useState,
   useRef,
@@ -74,6 +73,8 @@ export interface SelectProps
   fullWidth?: boolean;
   /** Disabled state */
   disabled?: boolean;
+  /** Ref to the container element */
+  ref?: React.Ref<HTMLDivElement>;
 }
 
 const ChevronDownIcon = ({ className }: { className?: string }) => (
@@ -127,7 +128,9 @@ const findNextEnabledIndex = (
     (_, i) => (currentIndex + i + 1) % options.length,
   );
 
-  return indices.find((i) => !options[i].disabled) ?? currentIndex;
+  return (
+    indices.find((i) => options[i] && !options[i].disabled) ?? currentIndex
+  );
 };
 
 const findPreviousEnabledIndex = (
@@ -142,317 +145,311 @@ const findPreviousEnabledIndex = (
     (_, i) => (currentIndex - i - 1 + options.length) % options.length,
   );
 
-  return indices.find((i) => !options[i].disabled) ?? currentIndex;
+  return (
+    indices.find((i) => options[i] && !options[i].disabled) ?? currentIndex
+  );
 };
+export const Select = ({
+  className,
+  options = [],
+  value,
+  onChange,
+  placeholder = 'Select an option',
+  helperText,
+  label,
+  error = false,
+  success = false,
+  size = 'medium',
+  fullWidth = true,
+  disabled = false,
+  id: providedId,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-describedby': ariaDescribedBy,
+  ref,
+  ..._props
+}: SelectProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const selectRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const generatedId = useId();
+  const id = providedId ?? generatedId;
+  const dropdownId = `${id}-dropdown`;
+  const helperTextId = `${id}-helper`;
 
-export const Select = forwardRef<HTMLDivElement, SelectProps>(
-  (
-    {
-      className,
-      options = [],
-      value,
-      onChange,
-      placeholder = 'Select an option',
-      helperText,
-      label,
-      error = false,
-      success = false,
-      size = 'medium',
-      fullWidth = true,
-      disabled = false,
-      id: providedId,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      'aria-describedby': ariaDescribedBy,
-      ..._props
-    },
-    ref,
-  ) => {
-    const [isOpen, setIsOpen] = useState(false);
-    const [focusedIndex, setFocusedIndex] = useState(-1);
-    const selectRef = useRef<HTMLDivElement>(null);
-    const dropdownRef = useRef<HTMLDivElement>(null);
-    const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
-    const generatedId = useId();
-    const id = providedId ?? generatedId;
-    const dropdownId = `${id}-dropdown`;
-    const helperTextId = `${id}-helper`;
+  // Determine state based on error/success props
+  let state: SelectState = 'default';
+  if (error) {
+    state = 'error';
+  } else if (success) {
+    state = 'success';
+  }
 
-    // Determine state based on error/success props
-    let state: SelectState = 'default';
-    if (error) {
-      state = 'error';
-    } else if (success) {
-      state = 'success';
+  // Create a comprehensive map for O(1) lookups - stores both option and index
+  // Memoized because it involves looping and creates objects for props
+  const optionsLookup = useMemo(
+    () =>
+      new Map(
+        options.map((option, index) => [option.value, { option, index }]),
+      ),
+    [options],
+  );
+
+  // Find selected option - O(1) lookup (simple operation, no memoization needed)
+  const selectedOption = value ? optionsLookup.get(value)?.option : undefined;
+
+  // Get display value - simple property access + nullish coalescing
+  const displayValue = selectedOption?.label ?? placeholder;
+
+  // Helper to find the appropriate initial focus index when opening dropdown
+  const getInitialFocusIndex = useCallback(() => {
+    if (!value) {
+      const firstEnabledIndex = options.findIndex((option) => !option.disabled);
+      return firstEnabledIndex !== -1 ? firstEnabledIndex : -1;
     }
+    return optionsLookup.get(value)?.index ?? 0;
+  }, [value, optionsLookup, options]);
 
-    // Create a comprehensive map for O(1) lookups - stores both option and index
-    // Memoized because it involves looping and creates objects for props
-    const optionsLookup = useMemo(
-      () =>
-        new Map(
-          options.map((option, index) => [option.value, { option, index }]),
-        ),
-      [options],
-    );
-
-    // Find selected option - O(1) lookup (simple operation, no memoization needed)
-    const selectedOption = value ? optionsLookup.get(value)?.option : undefined;
-
-    // Get display value - simple property access + nullish coalescing
-    const displayValue = selectedOption?.label ?? placeholder;
-
-    // Helper to find the appropriate initial focus index when opening dropdown
-    const getInitialFocusIndex = useCallback(() => {
-      if (!value) {
-        const firstEnabledIndex = options.findIndex(
-          (option) => !option.disabled,
-        );
-        return firstEnabledIndex !== -1 ? firstEnabledIndex : -1;
-      }
-      return optionsLookup.get(value)?.index ?? 0;
-    }, [value, optionsLookup, options]);
-
-    // Close dropdown when clicking outside
-    useEffect(() => {
-      const handleClickOutside = (event: MouseEvent) => {
-        if (
-          selectRef.current &&
-          !selectRef.current.contains(event.target as Node)
-        ) {
-          setIsOpen(false);
-          setFocusedIndex(-1);
-        }
-      };
-
-      document.addEventListener('mousedown', handleClickOutside);
-      return () =>
-        document.removeEventListener('mousedown', handleClickOutside);
-    }, []);
-
-    // Handle all keyboard navigation for the combobox - Wrapped in useCallback to prevent unnecessary re-renders
-    // Shared keyboard navigation logic that can be called from different contexts
-    const handleNavigationKey = useCallback(
-      (key: string) => {
-        if (disabled) return;
-
-        switch (key) {
-          case 'Enter':
-          case 'Space':
-            if (!isOpen) {
-              setIsOpen(true);
-              setFocusedIndex(getInitialFocusIndex());
-            } else if (focusedIndex >= 0) {
-              const focusedOption = options[focusedIndex];
-              if (focusedOption && !focusedOption.disabled) {
-                onChange?.(focusedOption.value);
-                setIsOpen(false);
-                setFocusedIndex(-1);
-              }
-            }
-            break;
-          case 'Escape':
-            setIsOpen(false);
-            setFocusedIndex(-1);
-            break;
-          case 'ArrowDown':
-            if (!isOpen) {
-              setIsOpen(true);
-              setFocusedIndex(getInitialFocusIndex());
-            } else {
-              const nextIndex = findNextEnabledIndex(options, focusedIndex);
-              setFocusedIndex(nextIndex);
-              optionRefs.current[nextIndex]?.scrollIntoView({
-                block: 'nearest',
-              });
-            }
-            break;
-          case 'ArrowUp':
-            if (!isOpen) {
-              setIsOpen(true);
-              setFocusedIndex(getInitialFocusIndex());
-            } else {
-              const prevIndex = findPreviousEnabledIndex(options, focusedIndex);
-              setFocusedIndex(prevIndex);
-              optionRefs.current[prevIndex]?.scrollIntoView({
-                block: 'nearest',
-              });
-            }
-            break;
-          default:
-            // Do nothing for other keys
-            break;
-        }
-      },
-      [disabled, isOpen, getInitialFocusIndex, options, onChange, focusedIndex],
-    );
-
-    // Main keyboard handler for the combobox
-    const handleKeyDown = useCallback(
-      (event: React.KeyboardEvent) => {
-        // Map actual event key to our descriptive key names
-        const mappedKey = KEY_MAP[event.key] || event.key;
-
-        if (isNavigationKey(mappedKey)) {
-          event.preventDefault();
-          handleNavigationKey(mappedKey);
-        }
-      },
-      [handleNavigationKey],
-    );
-
-    // Reusable keyboard handler for option elements
-    const handleOptionKeyDown = useCallback(
-      (event: React.KeyboardEvent) => {
-        // Map actual event key to our descriptive key names
-        const mappedKey = KEY_MAP[event.key] || event.key;
-
-        // Delegate navigation keys to the shared handler
-        if (isNavigationKey(mappedKey)) {
-          event.preventDefault();
-          event.stopPropagation();
-          // Use the shared navigation logic instead of synthetic events
-          handleNavigationKey(mappedKey);
-        }
-      },
-      [handleNavigationKey],
-    );
-
-    const handleOptionClick = useCallback(
-      (option: SelectOption) => {
-        if (option.disabled) return;
-        onChange?.(option.value);
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        selectRef.current &&
+        !selectRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false);
         setFocusedIndex(-1);
-      },
-      [onChange],
-    );
-
-    const handleSelectClick = useCallback(() => {
-      if (!disabled) {
-        setIsOpen(!isOpen);
-        if (!isOpen) {
-          setFocusedIndex(getInitialFocusIndex());
-        }
       }
-    }, [disabled, isOpen, getInitialFocusIndex]);
+    };
 
-    const handleMouseEnter = useCallback(
-      (e: React.MouseEvent) => {
-        const indexStr = (e.currentTarget as HTMLElement).dataset.index;
-        const index = parseInt(indexStr ?? '', 10);
-        if (!Number.isNaN(index) && index >= 0 && index < options.length) {
-          setFocusedIndex(index);
-        }
-      },
-      [options.length],
-    );
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
-    const handleOptionClickEvent = useCallback(
-      (e: React.MouseEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
+  // Handle all keyboard navigation for the combobox - Wrapped in useCallback to prevent unnecessary re-renders
+  // Shared keyboard navigation logic that can be called from different contexts
+  const handleNavigationKey = useCallback(
+    (key: string) => {
+      if (disabled) return;
 
-        const optionValue = (e.currentTarget as HTMLElement).dataset.value;
-        // O(1) lookup using the options map
-        const option = optionValue
-          ? optionsLookup.get(optionValue)?.option
-          : undefined;
+      switch (key) {
+        case 'Enter':
+        case 'Space':
+          if (!isOpen) {
+            setIsOpen(true);
+            setFocusedIndex(getInitialFocusIndex());
+          } else if (focusedIndex >= 0) {
+            const focusedOption = options[focusedIndex];
+            if (focusedOption && !focusedOption.disabled) {
+              onChange?.(focusedOption.value);
+              setIsOpen(false);
+              setFocusedIndex(-1);
+            }
+          }
+          break;
+        case 'Escape':
+          setIsOpen(false);
+          setFocusedIndex(-1);
+          break;
+        case 'ArrowDown':
+          if (!isOpen) {
+            setIsOpen(true);
+            setFocusedIndex(getInitialFocusIndex());
+          } else {
+            const nextIndex = findNextEnabledIndex(options, focusedIndex);
+            setFocusedIndex(nextIndex);
+            optionRefs.current[nextIndex]?.scrollIntoView({
+              block: 'nearest',
+            });
+          }
+          break;
+        case 'ArrowUp':
+          if (!isOpen) {
+            setIsOpen(true);
+            setFocusedIndex(getInitialFocusIndex());
+          } else {
+            const prevIndex = findPreviousEnabledIndex(options, focusedIndex);
+            setFocusedIndex(prevIndex);
+            optionRefs.current[prevIndex]?.scrollIntoView({
+              block: 'nearest',
+            });
+          }
+          break;
+        default:
+          // Do nothing for other keys
+          break;
+      }
+    },
+    [disabled, isOpen, getInitialFocusIndex, options, onChange, focusedIndex],
+  );
 
-        if (option) {
-          handleOptionClick(option);
-        }
-      },
-      [handleOptionClick, optionsLookup],
-    );
+  // Main keyboard handler for the combobox
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      // Map actual event key to our descriptive key names
+      const mappedKey = KEY_MAP[event.key] || event.key;
 
-    return (
-      <div className={cn('relative', fullWidth ? 'w-full' : 'w-auto')}>
-        {label && (
-          <label
-            htmlFor={id}
-            className='block text-sm font-medium text-gray-700 mb-1'
-          >
-            {label}
-          </label>
-        )}
+      if (isNavigationKey(mappedKey)) {
+        event.preventDefault();
+        handleNavigationKey(mappedKey);
+      }
+    },
+    [handleNavigationKey],
+  );
 
-        <div ref={selectRef} className='relative'>
-          <div
-            ref={ref}
-            id={id}
-            role='combobox'
-            aria-controls={dropdownId}
-            aria-expanded={isOpen}
-            aria-haspopup='listbox'
-            aria-label={ariaLabel}
-            aria-labelledby={ariaLabelledBy}
-            aria-describedby={[ariaDescribedBy, helperTextId]
-              .filter(Boolean)
-              .join(' ')}
-            tabIndex={disabled ? -1 : 0}
-            className={cn(
-              selectVariants({ size, state, fullWidth, disabled }),
-              className,
-            )}
-            onClick={handleSelectClick}
-            onKeyDown={handleKeyDown}
-          >
-            <span className='block truncate'>{displayValue}</span>
-            <ChevronDownIcon
-              className={selectChevronVariants({ size, isOpen })}
-            />
-          </div>
+  // Reusable keyboard handler for option elements
+  const handleOptionKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      // Map actual event key to our descriptive key names
+      const mappedKey = KEY_MAP[event.key] || event.key;
 
-          <div
-            ref={dropdownRef}
-            id={dropdownId}
-            className={selectDropdownVariants({ isOpen })}
-            role='listbox'
-            aria-label='Options'
-          >
-            {options.map((option, index) => (
-              <button
-                key={option.value}
-                ref={(el) => {
-                  optionRefs.current[index] = el;
-                }}
-                type='button'
-                role='option'
-                aria-selected={option.value === value}
-                data-value={option.value}
-                data-index={index}
-                disabled={option.disabled}
-                className={cn(
-                  selectOptionVariants({
-                    selected: option.value === value,
-                    disabled: option.disabled,
-                  }),
-                  focusedIndex === index && !option.disabled && 'bg-gray-100',
-                )}
-                onClick={handleOptionClickEvent}
-                onMouseEnter={handleMouseEnter}
-                onKeyDown={handleOptionKeyDown}
-              >
-                {option.label}
-              </button>
-            ))}
-            {options.length === 0 && (
-              <div className='px-3 py-2 text-sm text-gray-500'>
-                No options available
-              </div>
-            )}
-          </div>
+      // Delegate navigation keys to the shared handler
+      if (isNavigationKey(mappedKey)) {
+        event.preventDefault();
+        event.stopPropagation();
+        // Use the shared navigation logic instead of synthetic events
+        handleNavigationKey(mappedKey);
+      }
+    },
+    [handleNavigationKey],
+  );
+
+  const handleOptionClick = useCallback(
+    (option: SelectOption) => {
+      if (option.disabled) return;
+      onChange?.(option.value);
+      setIsOpen(false);
+      setFocusedIndex(-1);
+    },
+    [onChange],
+  );
+
+  const handleSelectClick = useCallback(() => {
+    if (!disabled) {
+      setIsOpen(!isOpen);
+      if (!isOpen) {
+        setFocusedIndex(getInitialFocusIndex());
+      }
+    }
+  }, [disabled, isOpen, getInitialFocusIndex]);
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent) => {
+      const indexStr = (e.currentTarget as HTMLElement).dataset.index;
+      const index = parseInt(indexStr ?? '', 10);
+      if (!Number.isNaN(index) && index >= 0 && index < options.length) {
+        setFocusedIndex(index);
+      }
+    },
+    [options.length],
+  );
+
+  const handleOptionClickEvent = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const optionValue = (e.currentTarget as HTMLElement).dataset.value;
+      // O(1) lookup using the options map
+      const option = optionValue
+        ? optionsLookup.get(optionValue)?.option
+        : undefined;
+
+      if (option) {
+        handleOptionClick(option);
+      }
+    },
+    [handleOptionClick, optionsLookup],
+  );
+
+  return (
+    <div className={cn('relative', fullWidth ? 'w-full' : 'w-auto')}>
+      {label && (
+        <label
+          htmlFor={id}
+          className='block text-sm font-medium text-gray-700 mb-1'
+        >
+          {label}
+        </label>
+      )}
+
+      <div ref={selectRef} className='relative'>
+        <div
+          ref={ref}
+          id={id}
+          role='combobox'
+          aria-controls={dropdownId}
+          aria-expanded={isOpen}
+          aria-haspopup='listbox'
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
+          aria-describedby={[ariaDescribedBy, helperTextId]
+            .filter(Boolean)
+            .join(' ')}
+          tabIndex={disabled ? -1 : 0}
+          className={cn(
+            selectVariants({ size, state, fullWidth, disabled }),
+            className,
+          )}
+          onClick={handleSelectClick}
+          onKeyDown={handleKeyDown}
+        >
+          <span className='block truncate'>{displayValue}</span>
+          <ChevronDownIcon
+            className={selectChevronVariants({ size, isOpen })}
+          />
         </div>
 
-        {helperText && (
-          <p id={helperTextId} className={helperTextVariants({ state })}>
-            {helperText}
-          </p>
-        )}
+        <div
+          ref={dropdownRef}
+          id={dropdownId}
+          className={selectDropdownVariants({ isOpen })}
+          role='listbox'
+          aria-label='Options'
+        >
+          {options.map((option, index) => (
+            <button
+              key={option.value}
+              ref={(el) => {
+                optionRefs.current[index] = el;
+              }}
+              type='button'
+              role='option'
+              aria-selected={option.value === value}
+              data-value={option.value}
+              data-index={index}
+              disabled={option.disabled}
+              className={cn(
+                selectOptionVariants({
+                  selected: option.value === value,
+                  disabled: option.disabled,
+                }),
+                focusedIndex === index && !option.disabled && 'bg-gray-100',
+              )}
+              onClick={handleOptionClickEvent}
+              onMouseEnter={handleMouseEnter}
+              onKeyDown={handleOptionKeyDown}
+            >
+              {option.label}
+            </button>
+          ))}
+          {options.length === 0 && (
+            <div className='px-3 py-2 text-sm text-gray-500'>
+              No options available
+            </div>
+          )}
+        </div>
       </div>
-    );
-  },
-);
+
+      {helperText && (
+        <p id={helperTextId} className={helperTextVariants({ state })}>
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+};
 
 Select.displayName = 'Select';

--- a/packages/@react-ui/src/lib/components/Switch/Switch.tsx
+++ b/packages/@react-ui/src/lib/components/Switch/Switch.tsx
@@ -1,11 +1,5 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import React, {
-  createContext,
-  forwardRef,
-  useContext,
-  useRef,
-  useState,
-} from 'react';
+import React, { createContext, useContext, useRef, useState } from 'react';
 
 import { cn } from '../../tools/classNames';
 
@@ -224,63 +218,60 @@ const switchSliderVariants = cva(
 interface SwitchContainerProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   'aria-checked'?: boolean | 'mixed';
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-const SwitchContainer = forwardRef<HTMLButtonElement, SwitchContainerProps>(
-  (
-    {
-      className,
-      children,
-      onClick,
-      tabIndex,
-      onKeyDown,
-      'aria-checked': ariaChecked = false,
-    },
-    ref,
-  ) => {
-    const { size, color, checked, disabled } = useContext(SwitchContext);
+const SwitchContainer = ({
+  className,
+  children,
+  onClick,
+  tabIndex,
+  onKeyDown,
+  'aria-checked': ariaChecked = false,
+  ref,
+}: SwitchContainerProps) => {
+  const { size, color, checked, disabled } = useContext(SwitchContext);
 
-    return (
-      <button
-        type='button'
-        ref={ref}
-        className={cn(
-          switchContainerVariants({ size, color, checked, disabled }),
-          className,
-        )}
-        onClick={onClick}
-        tabIndex={tabIndex}
-        onKeyDown={onKeyDown}
-        disabled={disabled}
-        role='switch'
-        aria-checked={ariaChecked as boolean | 'mixed' | undefined}
-      >
-        {children}
-      </button>
-    );
-  },
-);
+  return (
+    <button
+      type='button'
+      ref={ref}
+      className={cn(
+        switchContainerVariants({ size, color, checked, disabled }),
+        className,
+      )}
+      onClick={onClick}
+      tabIndex={tabIndex}
+      onKeyDown={onKeyDown}
+      disabled={disabled}
+      role='switch'
+      aria-checked={ariaChecked as boolean | 'mixed' | undefined}
+    >
+      {children}
+    </button>
+  );
+};
 
 SwitchContainer.displayName = 'SwitchContainer';
 
 // Slider component
-type SwitchSliderProps = React.HTMLAttributes<HTMLDivElement>;
+type SwitchSliderProps = React.HTMLAttributes<HTMLDivElement> & {
+  ref?: React.Ref<HTMLDivElement>;
+};
 
-const SwitchSlider = forwardRef<HTMLDivElement, SwitchSliderProps>(
-  ({ className }, ref) => {
-    const { size, checked, disabled } = useContext(SwitchContext);
+const SwitchSlider = ({ className, ref }: SwitchSliderProps) => {
+  const { size, checked, disabled } = useContext(SwitchContext);
 
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          switchSliderVariants({ size, checked, disabled }),
-          className,
-        )}
-      />
-    );
-  },
-);
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        switchSliderVariants({ size, checked, disabled }),
+        className,
+      )}
+    />
+  );
+};
 
 SwitchSlider.displayName = 'SwitchSlider';
 
@@ -292,111 +283,114 @@ export interface SwitchProps
       React.InputHTMLAttributes<HTMLInputElement>,
       'size' | 'color' | 'checked' | 'disabled'
     >,
-    SwitchBaseProps {}
+    SwitchBaseProps {
+  ref?: React.Ref<HTMLInputElement>;
+}
 
-export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
-  (
-    {
-      className: _className,
-      size = 'medium',
-      color = 'primary',
-      checked: checkedProp,
-      disabled = false,
-      onChange,
-      ...props
-    },
-    _ref,
+export const Switch = ({
+  className: _className,
+  size = 'medium',
+  color = 'primary',
+  checked: checkedProp,
+  disabled = false,
+  onChange,
+  ref: _ref,
+  ...props
+}: SwitchProps) => {
+  const [internalChecked, setInternalChecked] = useState<boolean>(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Use controlled or uncontrolled state - pure derived state handles prop changes automatically
+  const checked = checkedProp !== undefined ? checkedProp : internalChecked;
+
+  const handleSwitchClick = (
+    event: React.SyntheticEvent<HTMLButtonElement>,
   ) => {
-    const [internalChecked, setInternalChecked] = useState<boolean>(false);
-    const inputRef = useRef<HTMLInputElement>(null);
+    event.preventDefault();
+    event.stopPropagation();
 
-    // Use controlled or uncontrolled state - pure derived state handles prop changes automatically
-    const checked = checkedProp !== undefined ? checkedProp : internalChecked;
+    if (!disabled && inputRef.current) {
+      // Trigger the actual input click which will handle state updates and onChange callback
+      inputRef.current.click();
+    }
+  };
 
-    const handleSwitchClick = (
-      event: React.SyntheticEvent<HTMLButtonElement>,
-    ) => {
-      event.preventDefault();
-      event.stopPropagation();
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newChecked = event.target.checked;
 
-      if (!disabled && inputRef.current) {
-        // Trigger the actual input click which will handle state updates and onChange callback
-        inputRef.current.click();
-      }
-    };
+    // Update internal state only in uncontrolled mode
+    if (checkedProp === undefined) {
+      setInternalChecked(newChecked);
+    }
 
-    const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newChecked = event.target.checked;
+    // Call onChange callback once with the real event
+    onChange?.(event);
+  };
 
-      // Update internal state only in uncontrolled mode
-      if (checkedProp === undefined) {
-        setInternalChecked(newChecked);
-      }
-
-      // Call onChange callback once with the real event
-      onChange?.(event);
-    };
-
-    return (
-      <div className='inline-flex items-center'>
-        <SwitchContext.Provider
-          value={React.useMemo(
-            () => ({
-              size: size ?? 'medium',
-              color: color ?? 'primary',
-              checked: !!checked,
-              disabled: !!disabled,
-            }),
-            [size, color, checked, disabled],
-          )}
+  return (
+    <div className='inline-flex items-center'>
+      <SwitchContext.Provider
+        value={React.useMemo(
+          () => ({
+            size: (size ?? 'medium') as 'small' | 'medium',
+            color: (color ?? 'primary') as
+              | 'primary'
+              | 'secondary'
+              | 'success'
+              | 'danger'
+              | 'warning',
+            checked: !!checked,
+            disabled: !!disabled,
+          }),
+          [size, color, checked, disabled],
+        )}
+      >
+        <SwitchContainer
+          onClick={handleSwitchClick}
+          role='switch'
+          aria-checked={!!checked}
+          tabIndex={disabled ? -1 : 0}
+          onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) => {
+            if (e.key === ' ') {
+              e.preventDefault();
+              handleSwitchClick(e);
+            }
+          }}
         >
-          <SwitchContainer
-            onClick={handleSwitchClick}
-            role='switch'
-            aria-checked={!!checked}
-            tabIndex={disabled ? -1 : 0}
-            onKeyDown={(e) => {
-              if (e.key === ' ') {
-                e.preventDefault();
-                handleSwitchClick(e);
-              }
-            }}
-          >
-            <input
-              ref={inputRef}
-              type='checkbox'
-              className='sr-only'
-              checked={!!checked}
-              disabled={!!disabled}
-              onChange={handleInputChange}
-              aria-hidden='true'
-              tabIndex={-1}
-              id={props.id}
-              name={props.name}
-              onBlur={props.onBlur}
-              onFocus={props.onFocus}
-              onKeyDown={props.onKeyDown}
-              onKeyUp={props.onKeyUp}
-              aria-label={
-                (props as unknown as { 'aria-label'?: string })['aria-label']
-              }
-              aria-labelledby={
-                (props as unknown as { 'aria-labelledby'?: string })[
-                  'aria-labelledby'
-                ]
-              }
-              aria-describedby={
-                (props as unknown as { 'aria-describedby'?: string })[
-                  'aria-describedby'
-                ]
-              }
-            />
-            <SwitchSlider />
-          </SwitchContainer>
-        </SwitchContext.Provider>
-      </div>
-    );
-  },
-);
+          <input
+            ref={inputRef}
+            type='checkbox'
+            className='sr-only'
+            checked={!!checked}
+            disabled={!!disabled}
+            onChange={handleInputChange}
+            aria-hidden='true'
+            tabIndex={-1}
+            id={props.id}
+            name={props.name}
+            onBlur={props.onBlur}
+            onFocus={props.onFocus}
+            onKeyDown={props.onKeyDown}
+            onKeyUp={props.onKeyUp}
+            aria-label={
+              (props as unknown as { 'aria-label'?: string })['aria-label']
+            }
+            aria-labelledby={
+              (props as unknown as { 'aria-labelledby'?: string })[
+                'aria-labelledby'
+              ]
+            }
+            aria-describedby={
+              (props as unknown as { 'aria-describedby'?: string })[
+                'aria-describedby'
+              ]
+            }
+          />
+          <SwitchSlider />
+        </SwitchContainer>
+      </SwitchContext.Provider>
+    </div>
+  );
+};
 
 Switch.displayName = 'Switch';

--- a/packages/@react-ui/src/lib/components/Switch/Switch.tsx
+++ b/packages/@react-ui/src/lib/components/Switch/Switch.tsx
@@ -332,13 +332,8 @@ export const Switch = ({
       <SwitchContext.Provider
         value={React.useMemo(
           () => ({
-            size: (size ?? 'medium') as 'small' | 'medium',
-            color: (color ?? 'primary') as
-              | 'primary'
-              | 'secondary'
-              | 'success'
-              | 'danger'
-              | 'warning',
+            size: size ?? 'medium',
+            color: color ?? 'primary',
             checked: !!checked,
             disabled: !!disabled,
           }),

--- a/packages/@react-ui/src/lib/components/Tabs/Tabs.tsx
+++ b/packages/@react-ui/src/lib/components/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from 'class-variance-authority';
-import React, { createContext, forwardRef, useContext, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 
 import { cn } from '../../tools/classNames';
 import {
@@ -10,7 +10,17 @@ import {
 /**
  * Tab Component System
  *
- * A flexible tab component with context-based state management.
+ * A flexible tab component with conteconst TabContent = ({
+  className,
+  children,
+  id,
+  style,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'data-testid': dataTestId,
+  ref,
+  ...props
+}: TabContentProps) => {e management.
  * Built with accessibility in mind and styled with Tailwind CSS.
  *
  * @features
@@ -163,66 +173,64 @@ interface TabProps
   value: string;
   onSelect?: (value: string) => void;
   'data-testid'?: string;
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-const TabComponent = forwardRef<HTMLButtonElement, TabProps>(
-  (
-    {
-      className,
-      value: tabValue,
-      onSelect,
-      disabled,
-      children,
-      onClick,
-      onKeyDown,
-      onFocus,
-      onBlur,
-      id,
-      style,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      'data-testid': dataTestId,
-    },
-    ref,
-  ) => {
-    const { value, setValue, variant } = useContext(TabContext);
-    const active = tabValue === value;
+const TabComponent = ({
+  className,
+  value: tabValue,
+  onSelect,
+  disabled,
+  children,
+  onClick,
+  onKeyDown,
+  onFocus,
+  onBlur,
+  id,
+  style,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'data-testid': dataTestId,
+  ref,
+  ..._props
+}: TabProps) => {
+  const { value, setValue, variant } = useContext(TabContext);
+  const active = tabValue === value;
 
-    const handleClick = () => {
-      if (!disabled) {
-        setValue(tabValue);
-        onSelect?.(tabValue);
-      }
-    };
+  const handleClick = () => {
+    if (!disabled) {
+      setValue(tabValue);
+      onSelect?.(tabValue);
+    }
+  };
 
-    return (
-      <button
-        type='button'
-        ref={ref}
-        className={cn(tabVariants({ variant, active, disabled }), className)}
-        onClick={(e) => {
-          handleClick();
-          onClick?.(e);
-        }}
-        onKeyDown={onKeyDown}
-        onFocus={onFocus}
-        onBlur={onBlur}
-        disabled={!!disabled}
-        role='tab'
-        aria-selected={active}
-        aria-controls={`tabpanel-${tabValue}`}
-        id={id ?? `tab-${tabValue}`}
-        tabIndex={active ? 0 : -1}
-        style={style}
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
-        data-testid={dataTestId}
-      >
-        {children}
-      </button>
-    );
-  },
-);
+  return (
+    <button
+      type='button'
+      ref={ref}
+      className={cn(tabVariants({ variant, active, disabled }), className)}
+      onClick={(e) => {
+        handleClick();
+        onClick?.(e);
+      }}
+      onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      disabled={!!disabled}
+      role='tab'
+      aria-selected={active}
+      aria-controls={`tabpanel-${tabValue}`}
+      id={id ?? `tab-${tabValue}`}
+      tabIndex={active ? 0 : -1}
+      style={style}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      data-testid={dataTestId}
+    >
+      {children}
+    </button>
+  );
+};
 
 TabComponent.displayName = 'Tab';
 
@@ -236,51 +244,49 @@ TabComponent.defaultProps = {
 interface TabListProps extends React.HTMLAttributes<HTMLDivElement> {
   orientation?: 'horizontal' | 'vertical';
   'data-testid'?: string;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-const TabList = forwardRef<HTMLDivElement, TabListProps>(
-  (
-    {
-      className,
-      orientation = 'horizontal',
-      children,
-      id,
-      style,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      'data-testid': dataTestId,
-      onKeyDown: onKeyDownProp,
-    },
-    ref,
-  ) => {
-    const { variant, value, setValue } = useContext(TabContext);
+const TabList = ({
+  className,
+  orientation = 'horizontal',
+  children,
+  id,
+  style,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'data-testid': dataTestId,
+  onKeyDown: onKeyDownProp,
+  ref,
+  ..._props
+}: TabListProps) => {
+  const { variant, value, setValue } = useContext(TabContext);
 
-    // Handle keyboard navigation
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-      const tabInfo = getTabInfo(children);
-      handleTabKeyboardNavigation(event, tabInfo, value, orientation, setValue);
-      onKeyDownProp?.(event);
-    };
+  // Handle keyboard navigation
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const tabInfo = getTabInfo(children);
+    handleTabKeyboardNavigation(event, tabInfo, value, orientation, setValue);
+    onKeyDownProp?.(event);
+  };
 
-    return (
-      <div
-        ref={ref}
-        className={cn(tabListVariants({ variant, orientation }), className)}
-        role='tablist'
-        aria-orientation={orientation}
-        tabIndex={0}
-        onKeyDown={handleKeyDown}
-        id={id}
-        style={style}
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
-        data-testid={dataTestId}
-      >
-        {children}
-      </div>
-    );
-  },
-);
+  return (
+    <div
+      ref={ref}
+      className={cn(tabListVariants({ variant, orientation }), className)}
+      role='tablist'
+      aria-orientation={orientation}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      id={id}
+      style={style}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      data-testid={dataTestId}
+    >
+      {children}
+    </div>
+  );
+};
 
 TabList.displayName = 'TabList';
 
@@ -295,47 +301,45 @@ interface TabPanelProps extends React.HTMLAttributes<HTMLDivElement> {
   value: string;
   forceMount?: boolean;
   'data-testid'?: string;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-const TabPanel = forwardRef<HTMLDivElement, TabPanelProps>(
-  (
-    {
-      className,
-      value: panelValue,
-      forceMount = false,
-      children,
-      id,
-      style,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      'data-testid': dataTestId,
-    },
-    ref,
-  ) => {
-    const { value } = useContext(TabContext);
-    const active = panelValue === value;
+const TabPanel = ({
+  className,
+  value: panelValue,
+  forceMount = false,
+  children,
+  id,
+  style,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'data-testid': dataTestId,
+  ref,
+  ..._props
+}: TabPanelProps) => {
+  const { value } = useContext(TabContext);
+  const active = panelValue === value;
 
-    if (!active && !forceMount) {
-      return null;
-    }
+  if (!active && !forceMount) {
+    return null;
+  }
 
-    return (
-      <div
-        ref={ref}
-        className={cn('mt-4', !active && 'hidden', className)}
-        role='tabpanel'
-        aria-labelledby={ariaLabelledBy ?? `tab-${panelValue}`}
-        id={id ?? `tabpanel-${panelValue}`}
-        tabIndex={0}
-        style={style}
-        aria-label={ariaLabel}
-        data-testid={dataTestId}
-      >
-        {children}
-      </div>
-    );
-  },
-);
+  return (
+    <div
+      ref={ref}
+      className={cn('mt-4', !active && 'hidden', className)}
+      role='tabpanel'
+      aria-labelledby={ariaLabelledBy ?? `tab-${panelValue}`}
+      id={id ?? `tabpanel-${panelValue}`}
+      tabIndex={0}
+      style={style}
+      aria-label={ariaLabel}
+      data-testid={dataTestId}
+    >
+      {children}
+    </div>
+  );
+};
 
 TabPanel.displayName = 'TabPanel';
 
@@ -349,33 +353,32 @@ TabPanel.defaultProps = {
 interface TabContentProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
   'data-testid'?: string;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-const TabContent = forwardRef<HTMLDivElement, TabContentProps>(
-  (
-    {
-      className,
-      children,
-      id,
-      style,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      'data-testid': dataTestId,
-    },
-    ref,
-  ) => (
-    <div
-      ref={ref}
-      className={cn('tab-content', className)}
-      id={id}
-      style={style}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
-      data-testid={dataTestId}
-    >
-      {children}
-    </div>
-  ),
+const TabContent = ({
+  className,
+  children,
+  id,
+  style,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'data-testid': dataTestId,
+  ref,
+  ...props
+}: TabContentProps) => (
+  <div
+    ref={ref}
+    className={cn('tab-content', className)}
+    id={id}
+    style={style}
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledBy}
+    data-testid={dataTestId}
+    {...props}
+  >
+    {children}
+  </div>
 );
 
 TabContent.displayName = 'TabContent';

--- a/packages/@react-ui/src/lib/components/Tabs/Tabs.tsx
+++ b/packages/@react-ui/src/lib/components/Tabs/Tabs.tsx
@@ -10,17 +10,7 @@ import {
 /**
  * Tab Component System
  *
- * A flexible tab component with conteconst TabContent = ({
-  className,
-  children,
-  id,
-  style,
-  'aria-label': ariaLabel,
-  'aria-labelledby': ariaLabelledBy,
-  'data-testid': dataTestId,
-  ref,
-  ...props
-}: TabContentProps) => {e management.
+ * A flexible tab component with  context-based state management.
  * Built with accessibility in mind and styled with Tailwind CSS.
  *
  * @features

--- a/packages/@react-ui/src/lib/components/TextField/TextField.tsx
+++ b/packages/@react-ui/src/lib/components/TextField/TextField.tsx
@@ -1,6 +1,6 @@
 import { cva, type VariantProps } from 'class-variance-authority';
 import type React from 'react';
-import { forwardRef, useId, useMemo } from 'react';
+import { useId, useMemo } from 'react';
 import { cn } from '../../tools/classNames';
 import { createNumberInputWheelHandler } from '../../tools/formEventHelpers';
 
@@ -118,172 +118,108 @@ export interface TextFieldProps
   label?: string;
   hiddenLabel?: boolean;
   wrapperClassName?: string;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
-export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
-  (
-    {
-      className,
-      wrapperClassName,
-      size,
-      state: stateProp,
-      fullWidth,
-      disabled,
-      error,
-      helperText,
-      symbol,
-      label,
-      hiddenLabel = false,
-      id,
-      onWheel,
-      type,
-      ...props
-    },
-    ref,
-  ) => {
-    // Determine state based on error prop
-    const state = error ? 'error' : stateProp ?? 'default';
-    const hasSymbol = Boolean(symbol);
+export const TextField = ({
+  className,
+  wrapperClassName,
+  size,
+  state: stateProp,
+  fullWidth,
+  disabled,
+  error,
+  helperText,
+  symbol,
+  label,
+  hiddenLabel = false,
+  id,
+  onWheel,
+  type,
+  ref,
+  ...inputProps
+}: TextFieldProps) => {
+  // Determine state based on error prop
+  const state = error ? 'error' : stateProp ?? 'default';
+  const hasSymbol = Boolean(symbol);
 
-    // Generate ID if not provided
-    const generatedId = useId();
-    const inputId = id ?? `textfield-${generatedId}`;
-    const helperId = useMemo(() => `${inputId}-helper`, [inputId]);
-    const errorId = useMemo(() => `${inputId}-error`, [inputId]);
+  // Generate ID if not provided
+  const generatedId = useId();
+  const inputId = id ?? `textfield-${generatedId}`;
+  const helperId = useMemo(() => `${inputId}-helper`, [inputId]);
+  const errorId = useMemo(() => `${inputId}-error`, [inputId]);
 
-    // Create wheel handler for number inputs to prevent accidental value changes
-    const wheelHandler =
-      type === 'number' ? createNumberInputWheelHandler(onWheel) : onWheel;
+  // Create wheel handler for number inputs to prevent accidental value changes
+  const wheelHandler =
+    type === 'number' ? createNumberInputWheelHandler(onWheel) : onWheel;
 
-    return (
-      <div className={cn('relative', fullWidth && 'w-full', wrapperClassName)}>
-        {/* Label */}
-        {label && (
-          <label
-            htmlFor={inputId}
-            className={cn(
-              'block text-sm font-medium text-gray-700 mb-1',
-              hiddenLabel && 'sr-only',
-            )}
-          >
-            {label}
-          </label>
-        )}
-
-        {/* Input container */}
-        <div className='relative'>
-          {/* Symbol */}
-          {symbol && (
-            <div className={symbolVariants({ size })}>
-              {typeof symbol === 'string' ? <span>{symbol}</span> : symbol}
-            </div>
+  return (
+    <div className={cn('relative', fullWidth && 'w-full', wrapperClassName)}>
+      {/* Label */}
+      {label && (
+        <label
+          htmlFor={inputId}
+          className={cn(
+            'block text-sm font-medium text-gray-700 mb-1',
+            hiddenLabel && 'sr-only',
           )}
+        >
+          {label}
+        </label>
+      )}
 
-          {/* Input */}
-          <input
-            ref={ref}
-            id={inputId}
-            type={type}
-            className={cn(
-              textFieldVariants({
-                size,
-                state,
-                fullWidth,
-                disabled,
-                hasSymbol,
-              }),
-              className,
-            )}
-            disabled={!!disabled}
-            onWheel={wheelHandler}
-            aria-invalid={error ? 'true' : 'false'}
-            aria-describedby={
-              [error && errorId, helperText && !error && helperId]
-                .filter(Boolean)
-                .join(' ') || undefined
-            }
-            placeholder={props.placeholder}
-            defaultValue={props.defaultValue}
-            value={props.value}
-            autoComplete={props.autoComplete}
-            checked={props.checked}
-            defaultChecked={props.defaultChecked}
-            form={props.form}
-            formAction={props.formAction}
-            formEncType={props.formEncType}
-            formMethod={props.formMethod}
-            formNoValidate={props.formNoValidate}
-            formTarget={props.formTarget}
-            height={props.height}
-            list={props.list}
-            max={props.max}
-            maxLength={props.maxLength}
-            min={props.min}
-            minLength={props.minLength}
-            multiple={props.multiple}
-            name={props.name}
-            pattern={props.pattern}
-            readOnly={props.readOnly}
-            required={props.required}
-            src={props.src}
-            step={props.step}
-            width={props.width}
-            accept={props.accept}
-            alt={props.alt}
-            capture={props.capture}
-            onClick={props.onClick}
-            onFocus={props.onFocus}
-            onBlur={props.onBlur}
-            onChange={props.onChange}
-            onKeyDown={props.onKeyDown}
-            onKeyUp={props.onKeyUp}
-            onKeyPress={props.onKeyPress}
-            onInput={props.onInput}
-            onInvalid={props.onInvalid}
-            onSelect={props.onSelect}
-            onMouseDown={props.onMouseDown}
-            onMouseUp={props.onMouseUp}
-            onMouseEnter={props.onMouseEnter}
-            onMouseLeave={props.onMouseLeave}
-            onMouseMove={props.onMouseMove}
-            onMouseOver={props.onMouseOver}
-            onMouseOut={props.onMouseOut}
-            onContextMenu={props.onContextMenu}
-            onDoubleClick={props.onDoubleClick}
-            onDrag={props.onDrag}
-            onDragEnd={props.onDragEnd}
-            onDragEnter={props.onDragEnter}
-            onDragExit={props.onDragExit}
-            onDragLeave={props.onDragLeave}
-            onDragOver={props.onDragOver}
-            onDragStart={props.onDragStart}
-            onDrop={props.onDrop}
-            tabIndex={props.tabIndex}
-            role={props.role}
-            aria-label={props['aria-label']}
-            aria-labelledby={props['aria-labelledby']}
-            aria-required={props['aria-required']}
-            style={props.style}
-          />
-        </div>
-
-        {/* Error message */}
-        {error && (
-          <div id={errorId} className={helperTextVariants({ state: 'error' })}>
-            {error}
+      {/* Input container */}
+      <div className='relative'>
+        {/* Symbol */}
+        {symbol && (
+          <div className={symbolVariants({ size })}>
+            {typeof symbol === 'string' ? <span>{symbol}</span> : symbol}
           </div>
         )}
 
-        {/* Helper text */}
-        {helperText && !error && (
-          <div id={helperId} className={helperTextVariants({ state })}>
-            {helperText}
-          </div>
-        )}
+        {/* Input */}
+        <input
+          ref={ref}
+          id={inputId}
+          type={type}
+          className={cn(
+            textFieldVariants({
+              size,
+              state,
+              fullWidth,
+              disabled,
+              hasSymbol,
+            }),
+            className,
+          )}
+          disabled={!!disabled}
+          onWheel={wheelHandler}
+          aria-invalid={error ? 'true' : 'false'}
+          aria-describedby={
+            [error && errorId, helperText && !error && helperId]
+              .filter(Boolean)
+              .join(' ') || undefined
+          }
+          {...inputProps}
+        />
       </div>
-    );
-  },
-);
+
+      {/* Error message */}
+      {error && (
+        <div id={errorId} className={helperTextVariants({ state: 'error' })}>
+          {error}
+        </div>
+      )}
+
+      {/* Helper text */}
+      {helperText && !error && (
+        <div id={helperId} className={helperTextVariants({ state })}>
+          {helperText}
+        </div>
+      )}
+    </div>
+  );
+};
 
 TextField.displayName = 'TextField';
 

--- a/packages/@react-ui/src/lib/components/Typography/Typography.tsx
+++ b/packages/@react-ui/src/lib/components/Typography/Typography.tsx
@@ -1,6 +1,6 @@
 // packages/@react-ui/src/lib/components/Typography/Typography.tsx
 
-import React, { forwardRef } from 'react';
+import React from 'react';
 import { type VariantProps } from 'class-variance-authority';
 import { cn } from '../../tools/classNames';
 import { typographyVariants, variantElementMap } from './typography.config';
@@ -26,47 +26,44 @@ export interface TypographyProps
     VariantProps<typeof typographyVariants> {
   as?: keyof JSX.IntrinsicElements;
   children?: React.ReactNode;
+  ref?: React.Ref<HTMLElement>;
 }
 
-export const Typography = forwardRef<HTMLElement, TypographyProps>(
-  (
-    {
-      variant = 'body1',
-      align = 'inherit',
-      noWrap = false,
-      bold = false,
-      hyperlink = false,
-      strikethrough = false,
-      as = 'span',
-      className,
-      children,
-      ...props
-    },
-    ref,
-  ) => {
-    // Determine the element type
-    const Element = as ?? variantElementMap[variant ?? 'body1'];
+export const Typography = ({
+  variant = 'body1',
+  align = 'inherit',
+  noWrap = false,
+  bold = false,
+  hyperlink = false,
+  strikethrough = false,
+  as = 'span',
+  className,
+  children,
+  ref,
+  ...props
+}: TypographyProps) => {
+  // Determine the element type
+  const Element = as ?? variantElementMap[variant ?? 'body1'];
 
-    return React.createElement(
-      Element,
-      {
-        ref,
-        className: cn(
-          typographyVariants({
-            variant,
-            align,
-            noWrap,
-            bold,
-            hyperlink,
-            strikethrough,
-          }),
-          className,
-        ),
-        ...props,
-      },
-      children,
-    );
-  },
-);
+  return React.createElement(
+    Element,
+    {
+      ref,
+      className: cn(
+        typographyVariants({
+          variant: variant ?? 'body1',
+          align: align ?? 'inherit',
+          noWrap,
+          bold,
+          hyperlink,
+          strikethrough,
+        }),
+        className,
+      ),
+      ...props,
+    },
+    children,
+  );
+};
 
 Typography.displayName = 'Typography';

--- a/packages/@react-ui/src/lib/tools/ariaHelpers.ts
+++ b/packages/@react-ui/src/lib/tools/ariaHelpers.ts
@@ -1,0 +1,217 @@
+import type React from 'react';
+
+/**
+ * ARIA Helpers
+ *
+ * Utilities for consistent ARIA attribute handling across components.
+ * These helpers ensure accessibility best practices and reduce code duplication.
+ */
+
+/**
+ * ARIA attributes that can be extracted from props
+ */
+export interface AriaAttributes {
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
+  'aria-expanded'?: boolean | 'true' | 'false';
+  'aria-selected'?: boolean | 'true' | 'false';
+  'aria-checked'?: boolean | 'mixed' | 'true' | 'false';
+  'aria-pressed'?: boolean | 'mixed' | 'true' | 'false';
+  'aria-current'?:
+    | boolean
+    | 'page'
+    | 'step'
+    | 'location'
+    | 'date'
+    | 'time'
+    | 'true'
+    | 'false';
+  'aria-disabled'?: boolean | 'true' | 'false';
+  'aria-hidden'?: boolean | 'true' | 'false';
+  'aria-invalid'?: boolean | 'grammar' | 'spelling' | 'true' | 'false';
+  'aria-required'?: boolean | 'true' | 'false';
+  'aria-readonly'?: boolean | 'true' | 'false';
+  'aria-live'?: 'off' | 'assertive' | 'polite';
+  'aria-atomic'?: boolean | 'true' | 'false';
+  'aria-busy'?: boolean | 'true' | 'false';
+  'aria-controls'?: string;
+  'aria-owns'?: string;
+  'aria-activedescendant'?: string;
+  'aria-haspopup'?:
+    | boolean
+    | 'menu'
+    | 'listbox'
+    | 'tree'
+    | 'grid'
+    | 'dialog'
+    | 'true'
+    | 'false';
+  'aria-orientation'?: 'horizontal' | 'vertical';
+  'aria-valuemax'?: number;
+  'aria-valuemin'?: number;
+  'aria-valuenow'?: number;
+  'aria-valuetext'?: string;
+  role?: React.AriaRole;
+  tabIndex?: number;
+}
+
+/**
+ * Extracts ARIA attributes from a props object, returning both ARIA props
+ * and the remaining props separately.
+ *
+ * @param props - The props object to extract ARIA attributes from
+ * @returns Object with `ariaProps` and `otherProps`
+ *
+ * @example
+ * ```tsx
+ * const MyComponent = (props: MyComponentProps) => {
+ *   const { ariaProps, otherProps } = extractAriaProps(props);
+ *
+ *   return (
+ *     <div {...ariaProps} className={otherProps.className}>
+ *       {otherProps.children}
+ *     </div>
+ *   );
+ * };
+ * ```
+ */
+export const extractAriaProps = <T extends Record<string, unknown>>(
+  props: T,
+): {
+  ariaProps: Partial<AriaAttributes>;
+  otherProps: Omit<T, keyof AriaAttributes>;
+} => {
+  const ariaProps: Partial<AriaAttributes> = {};
+  const otherProps = { ...props };
+
+  // List of ARIA attributes to extract
+  const ariaKeys: Array<keyof AriaAttributes> = [
+    'aria-label',
+    'aria-labelledby',
+    'aria-describedby',
+    'aria-expanded',
+    'aria-selected',
+    'aria-checked',
+    'aria-pressed',
+    'aria-current',
+    'aria-disabled',
+    'aria-hidden',
+    'aria-invalid',
+    'aria-required',
+    'aria-readonly',
+    'aria-live',
+    'aria-atomic',
+    'aria-busy',
+    'aria-controls',
+    'aria-owns',
+    'aria-activedescendant',
+    'aria-haspopup',
+    'aria-orientation',
+    'aria-valuemax',
+    'aria-valuemin',
+    'aria-valuenow',
+    'aria-valuetext',
+    'role',
+    'tabIndex',
+  ];
+
+  ariaKeys.forEach((key) => {
+    if (key in props) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (ariaProps as any)[key] = props[key];
+      delete otherProps[key as keyof T];
+    }
+  });
+
+  return { ariaProps, otherProps };
+};
+
+/**
+ * Combines multiple aria-describedby values, filtering out falsy values.
+ * This is useful when you have multiple description sources (helper text, error text, etc.)
+ *
+ * @param ids - Array of potential aria-describedby IDs
+ * @returns Combined ID string or undefined if no valid IDs
+ *
+ * @example
+ * ```tsx
+ * const ariaDescribedby = combineAriaDescribedby([
+ *   error && errorId,
+ *   helperText && helperId,
+ *   props['aria-describedby']
+ * ]);
+ * ```
+ */
+export const combineAriaDescribedby = (
+  ids: Array<string | undefined | false | null>,
+): string | undefined => {
+  const validIds = ids.filter((id): id is string => Boolean(id));
+  return validIds.length > 0 ? validIds.join(' ') : undefined;
+};
+
+/**
+ * Ensures aria-expanded is returned as a proper boolean string for HTML attributes.
+ * React accepts boolean values, but for maximum compatibility, this converts to strings.
+ *
+ * @param expanded - The expanded state
+ * @returns String representation of the boolean or undefined
+ *
+ * @example
+ * ```tsx
+ * <div aria-expanded={normalizeAriaExpanded(isOpen)}>
+ * ```
+ */
+export const normalizeAriaExpanded = (
+  expanded?: boolean,
+): 'true' | 'false' | undefined => {
+  if (expanded === undefined) return undefined;
+  return expanded ? 'true' : 'false';
+};
+
+/**
+ * Ensures aria-selected is returned as a proper boolean string for HTML attributes.
+ *
+ * @param selected - The selected state
+ * @returns String representation of the boolean or undefined
+ */
+export const normalizeAriaSelected = (
+  selected?: boolean,
+): 'true' | 'false' | undefined => {
+  if (selected === undefined) return undefined;
+  return selected ? 'true' : 'false';
+};
+
+/**
+ * Ensures aria-checked is returned as a proper string for HTML attributes.
+ * Handles boolean values and the special 'mixed' state for indeterminate checkboxes.
+ *
+ * @param checked - The checked state (boolean or 'mixed')
+ * @returns String representation or undefined
+ */
+export const normalizeAriaChecked = (
+  checked?: boolean | 'mixed',
+): 'true' | 'false' | 'mixed' | undefined => {
+  if (checked === undefined) return undefined;
+  if (checked === 'mixed') return 'mixed';
+  return checked ? 'true' : 'false';
+};
+
+/**
+ * Creates a unique ID for accessibility purposes.
+ * Uses React's useId hook when available, falls back to a simple counter.
+ *
+ * @param prefix - Optional prefix for the ID
+ * @returns Unique ID string
+ *
+ * @example
+ * ```tsx
+ * const inputId = useAccessibleId('input');
+ * const labelId = useAccessibleId('label');
+ * ```
+ */
+let idCounter = 0;
+export const createAccessibleId = (prefix = 'accessible'): string => {
+  idCounter += 1;
+  return `${prefix}-${idCounter}`;
+};

--- a/packages/@react-ui/src/lib/tools/refHelpers.ts
+++ b/packages/@react-ui/src/lib/tools/refHelpers.ts
@@ -1,0 +1,98 @@
+import React from 'react';
+
+/**
+ * Ref Helpers
+ *
+ * Utilities for working with React refs, including merging multiple refs
+ * and handling different ref types consistently.
+ */
+
+/**
+ * Merges multiple refs into a single ref callback.
+ * This utility handles both function refs and ref objects, making it easy
+ * to forward refs while also maintaining internal ref usage.
+ *
+ * @param refs - Array of refs to merge (can be function refs, ref objects, or null/undefined)
+ * @returns A ref callback that calls all provided refs
+ *
+ * @example
+ * ```tsx
+ * const MyComponent = forwardRef<HTMLDivElement, MyComponentProps>(
+ *   (props, ref) => {
+ *     const internalRef = useRef<HTMLDivElement>(null);
+ *
+ *     return (
+ *       <div ref={mergeRefs([internalRef, ref])}>
+ *         {props.children}
+ *       </div>
+ *     );
+ *   }
+ * );
+ * ```
+ */
+export const mergeRefs =
+  <T>(
+    refs: Array<
+      React.MutableRefObject<T> | React.LegacyRef<T> | null | undefined
+    >,
+  ): React.RefCallback<T> =>
+  (value: T) => {
+    refs.forEach((ref) => {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref != null) {
+        // eslint-disable-next-line no-param-reassign
+        (ref as React.MutableRefObject<T | null>).current = value;
+      }
+    });
+  };
+
+/**
+ * Sets a value on a ref, handling both function refs and ref objects.
+ * This is useful when you need to programmatically set a ref value.
+ *
+ * @param ref - The ref to set the value on
+ * @param value - The value to set
+ *
+ * @example
+ * ```tsx
+ * const handleClick = () => {
+ *   setRef(inputRef, null); // Clear the ref
+ * };
+ * ```
+ */
+export const setRef = <T>(
+  ref: React.MutableRefObject<T> | React.LegacyRef<T> | null | undefined,
+  value: T,
+): void => {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref != null) {
+    // eslint-disable-next-line no-param-reassign
+    (ref as React.MutableRefObject<T | null>).current = value;
+  }
+};
+
+/**
+ * Creates a ref that calls a callback when the ref value changes.
+ * Useful for side effects when elements mount/unmount or change.
+ *
+ * @param callback - Function to call when ref changes
+ * @param deps - Dependencies for the callback (like useCallback deps)
+ * @returns A ref callback
+ *
+ * @example
+ * ```tsx
+ * const elementRef = useCallbackRef((element) => {
+ *   if (element) {
+ *     // Element mounted - setup resize observer, focus, etc.
+ *   } else {
+ *     // Element unmounted - cleanup
+ *   }
+ * }, []);
+ * ```
+ */
+export const useCallbackRef = <T>(
+  callback: (value: T | null) => void,
+  deps?: React.DependencyList,
+) => React.useCallback(callback, deps ?? []);

--- a/packages/@react-ui/src/lib/tools/tabNavigationHelpers.ts
+++ b/packages/@react-ui/src/lib/tools/tabNavigationHelpers.ts
@@ -53,7 +53,8 @@ export const findNextEnabledTab = (
     } else {
       idx = (idx - 1 + tabInfo.length) % tabInfo.length;
     }
-    if (!tabInfo[idx].disabled) {
+    const tab = tabInfo[idx];
+    if (tab && !tab.disabled) {
       return idx;
     }
   }
@@ -148,15 +149,18 @@ export const handleTabKeyboardNavigation = (
 
   if (shouldPreventDefault && nextIndex !== currentIndex) {
     event.preventDefault();
-    const newValue = tabInfo[nextIndex].value;
-    onNavigate(newValue);
+    const nextTab = tabInfo[nextIndex];
+    if (nextTab) {
+      const newValue = nextTab.value;
+      onNavigate(newValue);
 
-    // Focus the new tab
-    setTimeout(() => {
-      // Sanitize newValue before using it in DOM queries to prevent XSS attacks
-      const safeValue = CSS.escape(newValue);
-      const newTab = document.getElementById(`tab-${safeValue}`);
-      newTab?.focus();
-    }, 0);
+      // Focus the new tab
+      setTimeout(() => {
+        // Sanitize newValue before using it in DOM queries to prevent XSS attacks
+        const safeValue = CSS.escape(newValue);
+        const newTab = document.getElementById(`tab-${safeValue}`);
+        newTab?.focus();
+      }, 0);
+    }
   }
 };

--- a/packages/@react-ui/tsconfig.json
+++ b/packages/@react-ui/tsconfig.json
@@ -15,7 +15,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "strict": true,
-    "noEmit": false
+    "noEmit": false,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*"],
   "exclude": [


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the `@gmzh/react-ui` component library and its Storybook documentation. The most significant changes include a major rewrite and expansion of the Storybook app's `README.md`, updates to component APIs for better ref and aria support, and minor dependency and documentation updates to reflect React 19 compatibility. The following summarizes the most important changes:

**Documentation and Developer Experience**

* Major rewrite and expansion of `apps/storybook-react-ui/README.md` to provide detailed usage instructions, project structure, feature highlights, and contribution guidelines. The documentation now includes a live deployment link, clearer quick start, and best practices for adding new components.
* Added "React 19 Ready" to the feature list in `packages/@react-ui/README.md` to clarify compatibility.

**Component API Improvements (Ref and Aria Support)**

* Refactored `Button`, `Checkbox`, `Box`, `Flex`, and `Select` components to accept a `ref` prop directly (instead of using `forwardRef`), improving type safety and developer experience. Also improved aria prop handling for accessibility, especially in `Button` and `Checkbox`. [[1]](diffhunk://#diff-adafa02f94b38306eae378b8a8099da310182d6889a0ad3d6b3b0f8cae1247f0L3-R6) [[2]](diffhunk://#diff-adafa02f94b38306eae378b8a8099da310182d6889a0ad3d6b3b0f8cae1247f0R33-R36) [[3]](diffhunk://#diff-adafa02f94b38306eae378b8a8099da310182d6889a0ad3d6b3b0f8cae1247f0L49-R52) [[4]](diffhunk://#diff-adafa02f94b38306eae378b8a8099da310182d6889a0ad3d6b3b0f8cae1247f0L68-L93) [[5]](diffhunk://#diff-adafa02f94b38306eae378b8a8099da310182d6889a0ad3d6b3b0f8cae1247f0L103-R79) [[6]](diffhunk://#diff-adafa02f94b38306eae378b8a8099da310182d6889a0ad3d6b3b0f8cae1247f0L162-R114) [[7]](diffhunk://#diff-2ad868530a40823001c017edec1a06f0f434975f852bcb667b06005969391ec7L2-R5) [[8]](diffhunk://#diff-2ad868530a40823001c017edec1a06f0f434975f852bcb667b06005969391ec7R136) [[9]](diffhunk://#diff-2ad868530a40823001c017edec1a06f0f434975f852bcb667b06005969391ec7L152-L155) [[10]](diffhunk://#diff-2ad868530a40823001c017edec1a06f0f434975f852bcb667b06005969391ec7L172-R171) [[11]](diffhunk://#diff-2ad868530a40823001c017edec1a06f0f434975f852bcb667b06005969391ec7L187-R189) [[12]](diffhunk://#diff-2ad868530a40823001c017edec1a06f0f434975f852bcb667b06005969391ec7L227-R226) [[13]](diffhunk://#diff-2ad868530a40823001c017edec1a06f0f434975f852bcb667b06005969391ec7L264-R252) [[14]](diffhunk://#diff-2ad868530a40823001c017edec1a06f0f434975f852bcb667b06005969391ec7L309-L316) [[15]](diffhunk://#diff-d44103eba66459b1649f9f050aeea1d412167e8cfe40c210c86ae294bffa8c7eR138-R141) [[16]](diffhunk://#diff-d44103eba66459b1649f9f050aeea1d412167e8cfe40c210c86ae294bffa8c7eL155-R157) [[17]](diffhunk://#diff-d44103eba66459b1649f9f050aeea1d412167e8cfe40c210c86ae294bffa8c7eL181-R179) [[18]](diffhunk://#diff-0d4edb07464e6f6d08fa8dc388d9446e23a40a9c0673258149c77b7cc87afb7fR94-R97) [[19]](diffhunk://#diff-0d4edb07464e6f6d08fa8dc388d9446e23a40a9c0673258149c77b7cc87afb7fL110-R112) [[20]](diffhunk://#diff-0d4edb07464e6f6d08fa8dc388d9446e23a40a9c0673258149c77b7cc87afb7fL135-R133) [[21]](diffhunk://#diff-1cb429b22fbe04991a538aab068d497edffddaafd348366287a5d10e4f54fafeL4) [[22]](diffhunk://#diff-1cb429b22fbe04991a538aab068d497edffddaafd348366287a5d10e4f54fafeR76-R77)

**Linting and Code Quality**

* Updated ESLint config for the component library to allow prop spreading in JSX, which is helpful for component libraries.

**Version and Dependency Updates**

* Bumped the version of both the root and package-level `package.json` files from `0.2.8` to `0.2.9` to reflect new changes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-8ca5f0de272a22da08931f920413d6bf8aa5281450bcd2a66980b1ec244f4192L4-R4)

---

These changes collectively improve the usability, accessibility, and maintainability of the component library, while also providing clearer documentation and a better developer experience.